### PR TITLE
Fix index function

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ Connectr.prototype.remove = function (label) {
 };
 
 Connectr.prototype.index = function (index) {
-  this.currentFn = this.app.stack[i].handle;
+  this.currentFn = this.app.stack[index].handle;
   return this;
 };
 


### PR DESCRIPTION
I found a bug in the `index` method. The argument is `index`, but `this.app.stack[i].handle` was returned.
