### PR TITLE
Resolve issue where the stack cannot be located

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,12 @@ var merge = function(a, b){
   return a;
 };
 
-var stack = function(app) {
-  var stack = app.stack || (app._router? app._router.stack : null);
+var stack = function(connectr) {
+  var stack = connectr.stack || (connectr._router? connectr._router.stack : null);
+
+  if (!stack) {
+    stack = connectr.app.stack || (connectr.app._router? connectr.app._router.stack : null);
+  }
 
   if (!stack) {
     throw new Error('Cannot find stack');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connectr",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Connect wrapper that adds ability to insert middleware at arbitrary positions.\"",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I was trying to use this library in an Express 4 app, and was having trouble with the `order_stack` function because the `stack` function was receiving `this`, but was not looking at the `app` property of the input argument. I don't know if this is an Express 3 vs 4 thing, but it didn't appear to be.

Either way, this can probably be done cleaner if need be, but this solution worked for me.